### PR TITLE
Add input provider plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>batch-processor</artifactId>
-	<version>0.1.4-SNAPSHOT</version>
+	<version>0.2.0-SNAPSHOT</version>
 
 	<name>Batch Processor</name>
 	<description>A Batch Processor for SciJava Modules and Scripts</description>

--- a/src/main/java/org/scijava/batch/BatchModuleSearchActionFactory.java
+++ b/src/main/java/org/scijava/batch/BatchModuleSearchActionFactory.java
@@ -22,12 +22,12 @@ public class BatchModuleSearchActionFactory implements SearchActionFactory {
 	@Override
 	public boolean supports(final SearchResult result) {
 		return (result instanceof ModuleSearchResult)
-				&& batchService.supports(((ModuleSearchResult) result).info());
+				&& batchService.supportsModule(((ModuleSearchResult) result).info());
 	}
 
 	@Override
 	public SearchAction create(final SearchResult result) {
-		return new DefaultSearchAction("Batch", true, () -> {
+		return new DefaultSearchAction("Batch", () -> {
 			batchService.run(((ModuleSearchResult) result).info());
 		});
 	}

--- a/src/main/java/org/scijava/batch/BatchService.java
+++ b/src/main/java/org/scijava/batch/BatchService.java
@@ -4,28 +4,34 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import org.scijava.batch.input.BatchInput;
+import org.scijava.batch.input.BatchInputProvider;
+import org.scijava.module.Module;
 import org.scijava.module.ModuleInfo;
 import org.scijava.module.ModuleItem;
+import org.scijava.plugin.HandlerService;
 import org.scijava.service.SciJavaService;
 
-public interface BatchService extends SciJavaService {
+public interface BatchService extends HandlerService<BatchInput, BatchInputProvider<?>>, SciJavaService {
 	/**
 	 * Returns true if {@code moduleInfo} has at least one input item whose type
 	 * is supported by this service
 	 */
-	default public boolean supports(ModuleInfo moduleInfo) {
+	default public boolean supportsModule(ModuleInfo moduleInfo) {
 		for (ModuleItem<?> input : moduleInfo.inputs()) {
-			if (supports(input.getType()))
+			if (supportsItem(input))
 				return true;
 		}
 		return false;
 	}
+	
+	//default public getHandler(ModuleItem)
 
 	/**
 	 * Returns true if {@code type} can be populated with batch inputs provided
 	 * by this service
 	 */
-	public boolean supports(Class<?> type);
+	public boolean supportsItem(ModuleItem<?> moduleItem);
 
 	/**
 	 * Run the module described by {@link ModuleInfo} in batch.
@@ -38,7 +44,14 @@ public interface BatchService extends SciJavaService {
 	 */
 	default public List<ModuleItem<?>> batchableInputs(ModuleInfo moduleInfo) {
 		return StreamSupport.stream(moduleInfo.inputs().spliterator(), false)
-				.filter(item -> supports(item.getType()))
+				.filter(item -> supportsItem(item))
 				.collect(Collectors.toList());
 	}
+	
+	/**
+	 * Fill a provided ModuleItem with a given input object
+	 * @param <I>
+	 */
+	public <I> void fillInput(Module module, ModuleItem<?> moduleItem, I inputObject);
+
 }

--- a/src/main/java/org/scijava/batch/FileBatchService.java
+++ b/src/main/java/org/scijava/batch/FileBatchService.java
@@ -4,21 +4,24 @@ import java.io.File;
 import java.util.HashMap;
 
 import org.scijava.Priority;
+import org.scijava.batch.input.BatchInput;
+import org.scijava.batch.input.BatchInputProvider;
 import org.scijava.command.CommandService;
 import org.scijava.log.LogService;
+import org.scijava.module.Module;
 import org.scijava.module.ModuleInfo;
+import org.scijava.module.ModuleItem;
+import org.scijava.plugin.AbstractHandlerService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.service.AbstractService;
 import org.scijava.service.Service;
 
 @Plugin(type = Service.class, priority = Priority.LOW)
-public final class FileBatchService extends AbstractService implements
-		BatchService {
+public final class FileBatchService extends AbstractHandlerService<BatchInput, BatchInputProvider<?>> implements BatchService {
 
 	@Parameter
 	private LogService log;
-	
+
 	@Parameter
 	private CommandService commandService;
 
@@ -26,8 +29,23 @@ public final class FileBatchService extends AbstractService implements
 	 * Returns true if {@code type} is a {@link File}.
 	 */
 	@Override
-	public boolean supports(Class<?> type) {
-		return type.isAssignableFrom(File.class);
+	public boolean supportsItem(ModuleItem<?> moduleItem) {
+		BatchInputProvider<?> handler = getHandler(new BatchInput(File.class, moduleItem));
+		if (handler == null) {
+			return false;
+		}
+		return handler.canProvide(moduleItem);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <I> void fillInput(Module module, ModuleItem<?> moduleItem, I inputObject) {
+		BatchInputProvider<File> handler = (BatchInputProvider<File>) getHandler(new BatchInput(File.class, moduleItem));
+		if (handler == null) {
+			log.error("No handler found for input: " + moduleItem.getName());
+			return;
+		}
+		handler.populateInput(module, moduleItem, (File) inputObject);
 	}
 
 	@Override
@@ -37,10 +55,30 @@ public final class FileBatchService extends AbstractService implements
 			log.error("No compatible inputs (of type File) found.");
 			return;
 		}
+		
+		// 1) get input ModuleItems
+		// 2) choose ModuleItem
+		// 3) get suitable BatchInputProvider
+		// 4) get Iterator for ModuleItem
+
+		//for (getHandler(new BatchInput(File.class, moduleItem)).iterate(fileList)) {
+		//}
+		
 		// Call ModuleBatchProcessor with input moduleInfo
 		HashMap<String, Object> inputMap = new HashMap<>();
 		inputMap.put("moduleInfo", moduleInfo);
 		commandService.run(ModuleBatchProcessor.class, true, inputMap);
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Override
+	public Class<BatchInputProvider<?>> getPluginType() {
+		return (Class) BatchInputProvider.class;
+	}
+
+	@Override
+	public Class<BatchInput> getType() {
+		return BatchInput.class;
 	}
 
 }

--- a/src/main/java/org/scijava/batch/input/BatchInput.java
+++ b/src/main/java/org/scijava/batch/input/BatchInput.java
@@ -1,0 +1,36 @@
+package org.scijava.batch.input;
+
+import java.lang.reflect.Type;
+
+import org.scijava.module.ModuleItem;
+
+/**
+ * Currency for use with {@link BatchInputProvider} methods
+ * 
+ * 
+ * 
+ * @author Jan Eglinger
+ *
+ */
+public class BatchInput {
+	private final Type srcType;
+	private final ModuleItem<?> destItem;
+
+	public BatchInput(final Class<?> srcClass, final ModuleItem<?> destItem) {
+		this.srcType = srcClass;
+		this.destItem = destItem;
+	}
+
+	public BatchInput(final Type srcType, final ModuleItem<?> destItem) {
+		this.srcType = srcType;
+		this.destItem = destItem;
+	}
+
+	public Type sourceType() {
+		return srcType;
+	}
+
+	public ModuleItem<?> moduleItem() {
+		return destItem;
+	}
+}

--- a/src/main/java/org/scijava/batch/input/BatchInputProvider.java
+++ b/src/main/java/org/scijava/batch/input/BatchInputProvider.java
@@ -1,0 +1,32 @@
+
+package org.scijava.batch.input;
+
+import org.scijava.module.Module;
+import org.scijava.module.ModuleItem;
+import org.scijava.plugin.HandlerPlugin;
+
+public interface BatchInputProvider<I> extends HandlerPlugin<BatchInput> {
+
+	@Override
+	default public Class<BatchInput> getType() {
+		return BatchInput.class;
+	}
+
+	/**
+	 * Check if a given {@code ModuleItem} can be populated by this input provider.
+	 * Implementations should make sure to not only match the type of objects, but
+	 * also respect possible widget style settings, such as files, directories,
+	 * image files only, etc.
+	 *
+	 * @param moduleItem
+	 *            the input item that needs to be populated
+	 * @return true if this input provider can provide suitable objects
+	 */
+	public boolean canProvide(ModuleItem<?> moduleItem);
+	
+	public void populateInput(Module module, ModuleItem<?> moduleItem, I inputObject);
+
+	public String getTargetWidgetStyle(ModuleItem<?> moduleItem);
+
+	// public Iterable<O> iterate(Collection<I> fileList);
+}

--- a/src/main/java/org/scijava/batch/input/FileBatchInputProvider.java
+++ b/src/main/java/org/scijava/batch/input/FileBatchInputProvider.java
@@ -1,0 +1,65 @@
+
+package org.scijava.batch.input;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.scijava.module.Module;
+import org.scijava.module.ModuleItem;
+import org.scijava.plugin.AbstractHandlerPlugin;
+import org.scijava.plugin.Plugin;
+import org.scijava.widget.FileListWidget;
+import org.scijava.widget.FileWidget;
+
+@Plugin(type = BatchInputProvider.class)
+public class FileBatchInputProvider extends AbstractHandlerPlugin<BatchInput> implements
+	BatchInputProvider<File>
+{
+	@Override
+	public boolean supports(BatchInput input) {
+		return canProvide(input.moduleItem());
+	}
+
+	@Override
+	public boolean canProvide(ModuleItem<?> item) {
+		// we can't provide inputs for saving files
+		return item.getType() == File.class && !hasStyle(item, FileWidget.SAVE_STYLE);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void populateInput(Module module, ModuleItem<?> moduleItem, File inputObject) {
+		((ModuleItem<File>)moduleItem).setValue(module, inputObject);
+	}
+
+	@Override
+	public String getTargetWidgetStyle(ModuleItem<?> item) {
+		ArrayList<String> targetStyles = new ArrayList<>();
+
+		if (hasStyle(item, FileWidget.DIRECTORY_STYLE)) {
+			targetStyles.add(FileListWidget.DIRECTORIES_ONLY);
+		} else {
+			targetStyles.add(FileListWidget.FILES_ONLY);
+		}
+
+		// extensions?
+		String widgetStyle = item.getWidgetStyle();
+		if (widgetStyle != null) {
+			String[] styles = widgetStyle.trim().split("\\s*,\\s*");
+			for (String s : styles) {
+				if (s.startsWith("extensions")) { // TODO: use new constant from FileListWidget
+					targetStyles.add(s);
+				}
+			}			
+		}
+		return String.join(",", targetStyles);
+	}
+
+	private boolean hasStyle(ModuleItem<?> item, String style) {
+		String widgetStyle = item.getWidgetStyle();
+		if (widgetStyle == null) return false;
+		return Arrays.asList(widgetStyle.trim().split("\\s*,\\s*"))
+			.contains(style);
+	}
+}


### PR DESCRIPTION
This change makes batch processing extensible by allowing plugins implementing the `BatchInputProvider` interface to support custom script parameter inputs, such as `net.imagej.Dataset` which will be provided in the [`imagej-plugins-batch`](https://github.com/imagej/imagej-plugins-batch) project.

Because `BatchService` now extends `HandlerService`, I needed to rename the `supports()` methods more concisely into `supportsModule()` and `supportsItem()`, to avoid overriding `supports()` from `HandlerService`.
Since we are still pre-1.0.0, we can change the API freely, but bump the version to `0.2.0-SNAPSHOT` to reflect this API change.
