### PR TITLE
Creates a scijava task linked to the batch job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .classpath
 .project
 .settings/
+.idea/

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Jan Eglinger <jan.eglinger@fmi.ch> <jan.eglinger@gmail.com>

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 - 2018, Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
+Copyright (c) 2017 - 2022, Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>31.1.0</version>
+		<version>32.0.0-beta-6</version>
 		<relativePath />
 	</parent>
 
@@ -81,9 +81,6 @@
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)</license.copyrightOwners>
 		<license.excludes>**/scripts/**</license.excludes>
-
-		<!-- NB: Fiji ships with scijava-common-2.80.1.jar currently, so we need to adapt as long as no new pom-scijava is released -->
-		<scijava-common.version>2.88.0</scijava-common.version>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>27.0.1</version>
+		<version>31.1.0</version>
 		<relativePath />
 	</parent>
 
@@ -83,7 +83,7 @@
 		<license.excludes>**/scripts/**</license.excludes>
 
 		<!-- NB: Fiji ships with scijava-common-2.80.1.jar currently, so we need to adapt as long as no new pom-scijava is released -->
-		<scijava-common.version>2.80.1</scijava-common.version>
+		<scijava-common.version>2.88.0</scijava-common.version>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
 			<roles><role>founder</role></roles>
 			<properties><id>ctrueden</id></properties>
 		</contributor>
+		<contributor>
+			<name>Nicolas Chiaruttini</name>
+			<url>https://imagej.net/people/NicoKiaru</url>
+			<properties><id>NicoKiaru</id></properties>
+		</contributor>
 	</contributors>
 
 	<mailingLists>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 		<developer>
 			<id>imagejan</id>
 			<name>Jan Eglinger</name>
-			<url>https://imagej.net/User:Eglinger</url>
+			<url>https://imagej.net/people/imagejan</url>
 			<roles>
 				<role>founder</role>
 				<role>lead</role>
@@ -47,7 +47,7 @@
 	<contributors>
 		<contributor>
 			<name>Curtis Rueden</name>
-			<url>https://imagej.net/User:Rueden</url>
+			<url>https://imagej.net/people/ctrueden</url>
 			<roles><role>founder</role></roles>
 			<properties><id>ctrueden</id></properties>
 		</contributor>

--- a/src/main/java/org/scijava/batch/BatchModuleSearchActionFactory.java
+++ b/src/main/java/org/scijava/batch/BatchModuleSearchActionFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * A Batch Processor for SciJava Modules and Scripts
  * %%
- * Copyright (C) 2017 - 2018 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
+ * Copyright (C) 2017 - 2022 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/batch/BatchService.java
+++ b/src/main/java/org/scijava/batch/BatchService.java
@@ -2,7 +2,7 @@
  * #%L
  * A Batch Processor for SciJava Modules and Scripts
  * %%
- * Copyright (C) 2017 - 2018 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
+ * Copyright (C) 2017 - 2022 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/batch/FileBatchService.java
+++ b/src/main/java/org/scijava/batch/FileBatchService.java
@@ -2,7 +2,7 @@
  * #%L
  * A Batch Processor for SciJava Modules and Scripts
  * %%
- * Copyright (C) 2017 - 2018 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
+ * Copyright (C) 2017 - 2022 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/batch/FileScriptBatchProcessor.java
+++ b/src/main/java/org/scijava/batch/FileScriptBatchProcessor.java
@@ -2,7 +2,7 @@
  * #%L
  * A Batch Processor for SciJava Modules and Scripts
  * %%
- * Copyright (C) 2017 - 2018 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
+ * Copyright (C) 2017 - 2022 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/batch/MenuScriptBatchProcessor.java
+++ b/src/main/java/org/scijava/batch/MenuScriptBatchProcessor.java
@@ -2,7 +2,7 @@
  * #%L
  * A Batch Processor for SciJava Modules and Scripts
  * %%
- * Copyright (C) 2017 - 2018 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
+ * Copyright (C) 2017 - 2022 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/batch/ModuleBatchProcessor.java
+++ b/src/main/java/org/scijava/batch/ModuleBatchProcessor.java
@@ -50,6 +50,8 @@ import org.scijava.plugin.Plugin;
 import org.scijava.table.Column;
 import org.scijava.table.DefaultGenericTable;
 import org.scijava.table.Table;
+import org.scijava.task.Task;
+import org.scijava.task.TaskService;
 //import org.scijava.widget.FileWidget;
 
 @Plugin(type = Command.class, label = "Choose batch processing parameters", initializer = "initInputChoice")
@@ -75,6 +77,9 @@ public class ModuleBatchProcessor<T> extends DynamicCommand {
 	@SuppressWarnings("rawtypes")
 	@Parameter(type = ItemIO.OUTPUT)
 	private Table outputTable;
+
+	@Parameter
+	private TaskService taskService;
 
 	// -- Initializer --
 
@@ -114,13 +119,27 @@ public class ModuleBatchProcessor<T> extends DynamicCommand {
 			scriptModule.resolveOutput(outputKey);
 		}
 
+		String taskName = "Batch:";
+		if (scriptModule.getInfo()!=null) {
+			if (scriptModule.getInfo().getName()!=null)
+				taskName = scriptModule.getInfo().getName();
+		}
+		Task batchTask = taskService.createTask(taskName);
+		batchTask.setProgressMaximum(inputFileList.length);
+		batchTask.setCancelCallBack(() -> batchTask.setStatusMessage("Cancelling batch task..."));
 		for (File file : inputFileList) {
-			if(!processFile(scriptModule, inputModuleItem, file)) {
+			batchTask.setStatusMessage("process "+file.getName());
+			if (!(processFile(scriptModule, inputModuleItem, file))) {
 				log.warn("Terminating batch process.");
 				break; // end for loop
 			}
+			if (batchTask.isCanceled()) {
+				log.warn("Terminating batch process.");
+				break; // end for loop
+			}
+			batchTask.setProgressValue(batchTask.getProgressValue() + 1);
 		}
-
+		batchTask.finish();
 		// case File
 		//   feed files into input
 		// case Image (not needed if conversion works

--- a/src/main/java/org/scijava/batch/ModuleBatchProcessor.java
+++ b/src/main/java/org/scijava/batch/ModuleBatchProcessor.java
@@ -120,8 +120,7 @@ public class ModuleBatchProcessor<T> extends DynamicCommand {
 		}
 
 		String taskName = "Batch:";
-		if (scriptModule.getInfo()!=null) {
-			if (scriptModule.getInfo().getName()!=null)
+		if ((scriptModule.getInfo()!=null) && (scriptModule.getInfo().getName()!=null)) {
 				taskName = scriptModule.getInfo().getName();
 		}
 		Task batchTask = taskService.createTask(taskName);

--- a/src/main/java/org/scijava/batch/ModuleBatchProcessor.java
+++ b/src/main/java/org/scijava/batch/ModuleBatchProcessor.java
@@ -2,7 +2,7 @@
  * #%L
  * A Batch Processor for SciJava Modules and Scripts
  * %%
- * Copyright (C) 2017 - 2018 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
+ * Copyright (C) 2017 - 2022 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -120,8 +120,9 @@ public class ModuleBatchProcessor<T> extends DynamicCommand {
 		}
 
 		String taskName = "Batch:";
-		if ((scriptModule.getInfo()!=null) && (scriptModule.getInfo().getName()!=null)) {
-				taskName = scriptModule.getInfo().getName();
+		ModuleInfo scriptInfo = scriptModule.getInfo();
+		if (scriptInfo != null && scriptInfo.getName() != null) {
+			taskName = scriptInfo.getName();
 		}
 		Task batchTask = taskService.createTask(taskName);
 		batchTask.setProgressMaximum(inputFileList.length);

--- a/src/main/java/org/scijava/batch/ScriptInfoWidget.java
+++ b/src/main/java/org/scijava/batch/ScriptInfoWidget.java
@@ -2,7 +2,7 @@
  * #%L
  * A Batch Processor for SciJava Modules and Scripts
  * %%
- * Copyright (C) 2017 - 2018 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
+ * Copyright (C) 2017 - 2022 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/batch/SwingScriptInfoWidget.java
+++ b/src/main/java/org/scijava/batch/SwingScriptInfoWidget.java
@@ -2,7 +2,7 @@
  * #%L
  * A Batch Processor for SciJava Modules and Scripts
  * %%
- * Copyright (C) 2017 - 2018 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
+ * Copyright (C) 2017 - 2022 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/batch/input/BatchInput.java
+++ b/src/main/java/org/scijava/batch/input/BatchInput.java
@@ -2,7 +2,7 @@
  * #%L
  * A Batch Processor for SciJava Modules and Scripts
  * %%
- * Copyright (C) 2017 - 2018 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
+ * Copyright (C) 2017 - 2022 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/batch/input/BatchInputProvider.java
+++ b/src/main/java/org/scijava/batch/input/BatchInputProvider.java
@@ -2,7 +2,7 @@
  * #%L
  * A Batch Processor for SciJava Modules and Scripts
  * %%
- * Copyright (C) 2017 - 2018 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
+ * Copyright (C) 2017 - 2022 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/batch/input/FileBatchInputProvider.java
+++ b/src/main/java/org/scijava/batch/input/FileBatchInputProvider.java
@@ -2,7 +2,7 @@
  * #%L
  * A Batch Processor for SciJava Modules and Scripts
  * %%
- * Copyright (C) 2017 - 2018 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
+ * Copyright (C) 2017 - 2022 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/org/scijava/batch/BatchServiceTest.java
+++ b/src/test/java/org/scijava/batch/BatchServiceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * A Batch Processor for SciJava Modules and Scripts
  * %%
- * Copyright (C) 2017 - 2018 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
+ * Copyright (C) 2017 - 2022 Friedrich Miescher Institute for Biomedical Research, Basel (Switzerland)
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
* adds a synchronous task when a batch job is started
* upon task cancellation, the current item is processed.  Remaining ones are skipped

Unrelated:
* updates gitignore to remove intellij specific files
* bump parent pom to 31.1.0

This PR depends on the new functionalities added in scijava-common 2.88.0